### PR TITLE
Fix phpstan warnings related to PHPFlasher

### DIFF
--- a/app/Checks.php
+++ b/app/Checks.php
@@ -27,6 +27,7 @@ namespace App;
 
 use App\Models\Device;
 use App\Models\Notification;
+use App\Models\User;
 use Auth;
 use Cache;
 use Carbon\Carbon;
@@ -46,6 +47,7 @@ class Checks
 
         Cache::put('checks_popup_timeout', true, Config::get('checks_popup_timer', 5) * 60);
 
+        /** @var User $user */
         $user = Auth::user();
 
         if ($user->isAdmin()) {

--- a/composer.lock
+++ b/composer.lock
@@ -3509,16 +3509,16 @@
         },
         {
             "name": "php-flasher/flasher",
-            "version": "v0.9.0",
+            "version": "v0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-flasher/flasher.git",
-                "reference": "4e71dbc852f47cc7460a7544ac4f2131c7d5d295"
+                "reference": "2f024db71d13ab0fcbe95d2558acc2952967e548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-flasher/flasher/zipball/4e71dbc852f47cc7460a7544ac4f2131c7d5d295",
-                "reference": "4e71dbc852f47cc7460a7544ac4f2131c7d5d295",
+                "url": "https://api.github.com/repos/php-flasher/flasher/zipball/2f024db71d13ab0fcbe95d2558acc2952967e548",
+                "reference": "2f024db71d13ab0fcbe95d2558acc2952967e548",
                 "shasum": ""
             },
             "require": {
@@ -3566,7 +3566,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-flasher/flasher/issues",
-                "source": "https://github.com/php-flasher/flasher/tree/v0.9.0"
+                "source": "https://github.com/php-flasher/flasher/tree/v0.9.3"
             },
             "funding": [
                 {
@@ -3586,20 +3586,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-10-23T16:08:27+00:00"
+            "time": "2021-10-24T22:18:23+00:00"
         },
         {
             "name": "php-flasher/flasher-laravel",
-            "version": "v0.9.0",
+            "version": "v0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-flasher/flasher-laravel.git",
-                "reference": "d5f21d22c66da1ebd958b17c237281f49f3e4671"
+                "reference": "d4b5ed010630bedfb5c582447d9ad59d535ac4e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-flasher/flasher-laravel/zipball/d5f21d22c66da1ebd958b17c237281f49f3e4671",
-                "reference": "d5f21d22c66da1ebd958b17c237281f49f3e4671",
+                "url": "https://api.github.com/repos/php-flasher/flasher-laravel/zipball/d4b5ed010630bedfb5c582447d9ad59d535ac4e6",
+                "reference": "d4b5ed010630bedfb5c582447d9ad59d535ac4e6",
                 "shasum": ""
             },
             "require": {
@@ -3658,7 +3658,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-flasher/flasher-laravel/issues",
-                "source": "https://github.com/php-flasher/flasher-laravel/tree/v0.9.0"
+                "source": "https://github.com/php-flasher/flasher-laravel/tree/v0.9.3"
             },
             "funding": [
                 {
@@ -3678,7 +3678,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-10-23T16:20:51+00:00"
+            "time": "2021-10-24T22:18:23+00:00"
         },
         {
             "name": "phpmailer/phpmailer",


### PR DESCRIPTION
This PR Fix phpstan warnings related to [PHPFlasher](https://php-flasher.github.io/) in this PR : https://github.com/librenms/librenms/pull/13401

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
